### PR TITLE
fix: null-guard argless analytic functions in JSQLColumResolver (#146)

### DIFF
--- a/src/main/java/ai/starlake/transpiler/JSQLExpressionColumnResolver.java
+++ b/src/main/java/ai/starlake/transpiler/JSQLExpressionColumnResolver.java
@@ -33,6 +33,7 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
 import net.sf.jsqlparser.statement.select.LateralSubSelect;
+import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -200,7 +201,31 @@ public class JSQLExpressionColumnResolver extends ExpressionVisitorAdapter<List<
   @Override
   public <S> List<JdbcColumn> visit(AnalyticExpression function, S context) {
     functions.add(function);
-    return function.getExpression().accept(this, context);
+    JdbcColumn col = new JdbcColumn(function.getName(), function);
+
+    // Argless analytics (row_number(), rank(), dense_rank(), percent_rank(), cume_dist())
+    // have a null inner expression; only argful ones (sum(x) OVER ..., lag(x) OVER ...) carry one.
+    if (function.getExpression() != null) {
+      col.add(function.getExpression().accept(this, context));
+    }
+
+    ExpressionList<?> partitionExpressions = function.getPartitionExpressionList();
+    if (partitionExpressions != null) {
+      for (Expression e : partitionExpressions) {
+        col.add(e.accept(this, context));
+      }
+    }
+
+    List<OrderByElement> orderByElements = function.getOrderByElements();
+    if (orderByElements != null) {
+      for (OrderByElement e : orderByElements) {
+        if (e.getExpression() != null) {
+          col.add(e.getExpression().accept(this, context));
+        }
+      }
+    }
+
+    return List.of(col);
   }
 
 

--- a/src/test/java/ai/starlake/transpiler/JSQLColumnResolverTest.java
+++ b/src/test/java/ai/starlake/transpiler/JSQLColumnResolverTest.java
@@ -259,6 +259,29 @@ public class JSQLColumnResolverTest extends AbstractColumnResolverTest {
   }
 
 
+  // https://github.com/starlake-ai/jsqltranspiler/issues/146
+  // Argless analytic functions like row_number() used to NPE in the resolver because
+  // AnalyticExpression.getExpression() returns null for them.
+  @Test
+  void testArglessAnalyticFunctions() throws JSQLParserException, SQLException {
+    String[][] schemaDef = {{"customer", "c_id", "c_email"}};
+    JSQLColumResolver resolver = new JSQLColumResolver("mycat", "myschema", schemaDef);
+    resolver.setErrorMode(JdbcMetaData.ErrorMode.STRICT);
+
+    // Each of these used to throw NPE
+    for (String sql : new String[] {
+        "SELECT row_number() OVER (PARTITION BY c_email) FROM customer",
+        "SELECT row_number() OVER (ORDER BY c_email) FROM customer",
+        "SELECT row_number() OVER (PARTITION BY c_id ORDER BY c_email) FROM customer",
+        "SELECT rank() OVER (PARTITION BY c_email) FROM customer",
+        "SELECT dense_rank() OVER (PARTITION BY c_email) FROM customer",
+        "SELECT percent_rank() OVER (PARTITION BY c_email) FROM customer",
+        "SELECT cume_dist() OVER (PARTITION BY c_email) FROM customer"}) {
+      Assertions.assertThat(resolver.getResolvedStatementText(sql)).isNotNull();
+      Assertions.assertThat(resolver.getResultSetMetaData(sql)).isNotNull();
+    }
+  }
+
   @Test
   void testFunction() throws JSQLParserException, SQLException, InvocationTargetException,
       NoSuchMethodException, InstantiationException, IllegalAccessException {

--- a/src/test/java/ai/starlake/transpiler/JSQLColumnResolverTest.java
+++ b/src/test/java/ai/starlake/transpiler/JSQLColumnResolverTest.java
@@ -269,8 +269,7 @@ public class JSQLColumnResolverTest extends AbstractColumnResolverTest {
     resolver.setErrorMode(JdbcMetaData.ErrorMode.STRICT);
 
     // Each of these used to throw NPE
-    for (String sql : new String[] {
-        "SELECT row_number() OVER (PARTITION BY c_email) FROM customer",
+    for (String sql : new String[] {"SELECT row_number() OVER (PARTITION BY c_email) FROM customer",
         "SELECT row_number() OVER (ORDER BY c_email) FROM customer",
         "SELECT row_number() OVER (PARTITION BY c_id ORDER BY c_email) FROM customer",
         "SELECT rank() OVER (PARTITION BY c_email) FROM customer",


### PR DESCRIPTION
## Summary
- Fixes #146: `JSQLColumResolver.getResolvedStatementText` / `getResultSetMetaData` NPE on argless analytic functions (`row_number()`, `rank()`, `dense_rank()`, `percent_rank()`, `cume_dist()`) used inside `OVER (...)`.
- `JSQLExpressionColumnResolver.visit(AnalyticExpression)` now null-guards the inner expression and walks `PARTITION BY` / `ORDER BY` sub-expressions, mirroring the `visit(Function)` pattern.
- Added `testArglessAnalyticFunctions` covering the exact reproductions from the issue plus the other affected variants.

## Test plan
- [x] `./gradlew test --tests "ai.starlake.transpiler.JSQLColumnResolverTest"` — all green, including the new test.
- [x] `./gradlew test --tests "ai.starlake.transpiler.JSQLResolverTest" --tests "ai.starlake.transpiler.JSQLReplacerTest"` — no regressions in sibling resolvers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)