### PR TITLE
feat: emit DuckDB VARIANT bracket access for Snowflake variant paths

### DIFF
--- a/src/main/java/ai/starlake/transpiler/JSQLExpressionTranspiler.java
+++ b/src/main/java/ai/starlake/transpiler/JSQLExpressionTranspiler.java
@@ -133,7 +133,8 @@ public class JSQLExpressionTranspiler extends ExpressionDeParser {
   /**
    * Controls how Snowflake VARIANT path expressions like {@code v:a.b} are transpiled: against a
    * DuckDB {@code JSON} column (arrow operators) or against a DuckDB 1.4+ {@code VARIANT} column
-   * (bracket access, which preserves the stored types).
+   * (bracket access, which preserves the stored types). Defaults to {@code VARIANT}; pass
+   * {@code VARIANT_MODE=JSON} as parameter or system property to target JSON columns instead.
    */
   public enum VariantMode {
     JSON, VARIANT;
@@ -2936,11 +2937,13 @@ public class JSQLExpressionTranspiler extends ExpressionDeParser {
   }
 
   public VariantMode getVariantMode() {
-    if ("VARIANT".equalsIgnoreCase(String.valueOf(parameterMap.get("VARIANT_MODE")))
-        || "VARIANT".equalsIgnoreCase(String.valueOf(System.getProperties().get("VARIANT_MODE")))) {
-      return VariantMode.VARIANT;
+    String configured =
+        parameterMap.containsKey("VARIANT_MODE") ? String.valueOf(parameterMap.get("VARIANT_MODE"))
+            : System.getProperty("VARIANT_MODE");
+    if ("JSON".equalsIgnoreCase(configured)) {
+      return VariantMode.JSON;
     }
-    return VariantMode.JSON;
+    return VariantMode.VARIANT;
   }
 
   @Override

--- a/src/main/java/ai/starlake/transpiler/JSQLExpressionTranspiler.java
+++ b/src/main/java/ai/starlake/transpiler/JSQLExpressionTranspiler.java
@@ -71,6 +71,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -127,6 +128,15 @@ public class JSQLExpressionTranspiler extends ExpressionDeParser {
 
   enum GeoMode {
     GEOGRAPHY, GEOMETRY;
+  }
+
+  /**
+   * Controls how Snowflake VARIANT path expressions like {@code v:a.b} are transpiled: against a
+   * DuckDB {@code JSON} column (arrow operators) or against a DuckDB 1.4+ {@code VARIANT} column
+   * (bracket access, which preserves the stored types).
+   */
+  public enum VariantMode {
+    JSON, VARIANT;
   }
 
   enum TranspiledFunction {
@@ -2925,20 +2935,45 @@ public class JSQLExpressionTranspiler extends ExpressionDeParser {
     return builder;
   }
 
+  public VariantMode getVariantMode() {
+    if ("VARIANT".equalsIgnoreCase(String.valueOf(parameterMap.get("VARIANT_MODE")))
+        || "VARIANT".equalsIgnoreCase(String.valueOf(System.getProperties().get("VARIANT_MODE")))) {
+      return VariantMode.VARIANT;
+    }
+    return VariantMode.JSON;
+  }
+
   @Override
   public <S> StringBuilder visit(JsonExpression e, S context) {
-    // new CastExpression(e.getExpression(), "JSON").accept(this, context);
+    final int startPosition = builder.length();
     e.getExpression().accept(this, context);
 
     for (Map.Entry<Expression, String> ident : e.getIdentList()) {
       String operatorStr = ident.getValue();
+      Expression expr = ident.getKey();
+
       if (operatorStr.equalsIgnoreCase(":")) {
+        // Snowflake VARIANT path access, e. g. v:a.b or v:arr[0]::string
+        // the cast binds inside the ident: v:a.b::string parses as JsonExpression(v, [a.b::string])
+        CastExpression castExpression = null;
+        if (expr instanceof CastExpression) {
+          castExpression = (CastExpression) expr;
+          expr = castExpression.getLeftExpression();
+        }
+
+        if (expr instanceof Column) {
+          appendVariantPath(startPosition, (Column) expr, castExpression);
+          continue;
+        }
+
         builder.append("->");
+        if (castExpression != null) {
+          expr = castExpression;
+        }
       } else {
         builder.append(operatorStr);
       }
 
-      Expression expr = ident.getKey();
       if (expr instanceof Column) {
         new StringValue(expr.toString()).accept(this, context);
       } else if (expr instanceof ArrayConstructor) {
@@ -2954,6 +2989,85 @@ public class JSQLExpressionTranspiler extends ExpressionDeParser {
       }
     }
     return builder;
+  }
+
+  /**
+   * Appends a Snowflake {@code :} path held in a (possibly dotted) Column, with an optional
+   * trailing array subscript and an optional cast, e. g. {@code v:a.b::string} or {@code v:arr[0]}.
+   *
+   * <p>
+   * In {@link VariantMode#VARIANT} the path is written as DuckDB bracket access {@code v['a']['b']}
+   * which preserves the types stored in a VARIANT column; numeric array subscripts are shifted from
+   * Snowflake's 0-based to DuckDB's 1-based indexing. In {@link VariantMode#JSON} the path is
+   * written with one arrow per step {@code v->'a'->'b'}, using {@code ->>} on the final step when
+   * the path is cast to a text type so the result is the unquoted string, matching Snowflake.
+   * </p>
+   */
+  private void appendVariantPath(int startPosition, Column column, CastExpression castExpression) {
+    final boolean variantMode = getVariantMode() == VariantMode.VARIANT;
+    final boolean textCast =
+        castExpression != null && CastExpression.isText(castExpression.getColDataType());
+
+    ArrayList<String> keys = new ArrayList<>();
+    Table table = column.getTable();
+    if (table != null && table.getFullyQualifiedName() != null
+        && !table.getFullyQualifiedName().isEmpty()) {
+      for (String part : table.getFullyQualifiedName().split("\\.")) {
+        keys.add(unquoteIdentifier(part));
+      }
+    }
+    keys.add(unquoteIdentifier(column.getColumnName()));
+
+    ArrayConstructor arrayConstructor = column.getArrayConstructor();
+    List<? extends Expression> subscripts =
+        arrayConstructor != null ? arrayConstructor.getExpressions() : Collections.emptyList();
+
+    for (int i = 0; i < keys.size(); i++) {
+      boolean last = i == keys.size() - 1 && subscripts.isEmpty();
+      String key = keys.get(i).replace("'", "''");
+      if (variantMode) {
+        builder.append("['").append(key).append("']");
+      } else {
+        builder.append(textCast && last ? "->>" : "->").append("'").append(key).append("'");
+      }
+    }
+
+    for (int i = 0; i < subscripts.size(); i++) {
+      boolean last = i == subscripts.size() - 1;
+      Expression subscript = subscripts.get(i);
+      if (variantMode) {
+        builder.append("[");
+        if (subscript instanceof LongValue) {
+          // DuckDB bracket access on VARIANT arrays is 1-based while Snowflake is 0-based
+          builder.append(((LongValue) subscript).getValue() + 1);
+        } else if (subscript instanceof StringValue) {
+          subscript.accept(this, null);
+        } else {
+          subscript.accept(this, null);
+          builder.append(" + 1");
+        }
+        builder.append("]");
+      } else {
+        builder.append(textCast && last ? "->>" : "->");
+        subscript.accept(this, null);
+      }
+    }
+
+    if (castExpression != null) {
+      if (!variantMode) {
+        // arrow operators bind weaker than "::", so the path needs parentheses
+        builder.insert(startPosition, "(");
+        builder.append(")");
+      }
+      builder.append("::").append(rewriteType(castExpression.getColDataType()));
+    }
+  }
+
+  private static String unquoteIdentifier(String identifier) {
+    if (identifier.length() > 1 && identifier.startsWith("\"") && identifier.endsWith("\"")) {
+      return identifier.substring(1, identifier.length() - 1);
+    }
+    return identifier;
   }
 
   public <S> StringBuilder visit(ArrayConstructor arrayConstructor, S context) {

--- a/src/main/java/ai/starlake/transpiler/snowflake/SnowflakeExpressionTranspiler.java
+++ b/src/main/java/ai/starlake/transpiler/snowflake/SnowflakeExpressionTranspiler.java
@@ -1188,7 +1188,8 @@ public class SnowflakeExpressionTranspiler extends RedshiftExpressionTranspiler 
     } else if (colDataType.getDataType().equalsIgnoreCase("NUMBER")) {
       colDataType.setDataType("NUMERIC");
     } else if (colDataType.getDataType().equalsIgnoreCase("VARIANT")) {
-      colDataType.setDataType("VARCHAR");
+      // DuckDB 1.4+ has a native VARIANT type
+      colDataType.setDataType(getVariantMode() == VariantMode.VARIANT ? "VARIANT" : "VARCHAR");
     }
     return super.rewriteType(colDataType);
   }

--- a/src/test/java/ai/starlake/transpiler/JSQLTranspilerTest.java
+++ b/src/test/java/ai/starlake/transpiler/JSQLTranspilerTest.java
@@ -176,7 +176,13 @@ public class JSQLTranspilerTest {
                 ? JSQLExpressionTranspiler.GeoMode.GEOGRAPHY
                 : JSQLExpressionTranspiler.GeoMode.GEOMETRY;
 
-        SQLTest test = new SQLTest(inputDialect, outputDialect, Map.of("GEO_MODE", geoMode));
+        JSQLExpressionTranspiler.VariantMode variantMode =
+            file.getName().toLowerCase().contains("variant")
+                ? JSQLExpressionTranspiler.VariantMode.VARIANT
+                : JSQLExpressionTranspiler.VariantMode.JSON;
+
+        SQLTest test = new SQLTest(inputDialect, outputDialect,
+            Map.of("GEO_MODE", geoMode, "VARIANT_MODE", variantMode));
         int r = 0;
         while ((line = bufferedReader.readLine()) != null) {
           r++;
@@ -223,7 +229,12 @@ public class JSQLTranspilerTest {
                     ? JSQLExpressionTranspiler.GeoMode.GEOGRAPHY
                     : JSQLExpressionTranspiler.GeoMode.GEOMETRY;
 
-                test = new SQLTest(inputDialect, outputDialect, Map.of("GEO_MODE", geoMode));
+                variantMode = file.getName().toLowerCase().contains("variant")
+                    ? JSQLExpressionTranspiler.VariantMode.VARIANT
+                    : JSQLExpressionTranspiler.VariantMode.JSON;
+
+                test = new SQLTest(inputDialect, outputDialect,
+                    Map.of("GEO_MODE", geoMode, "VARIANT_MODE", variantMode));
                 test.line = r;
               }
 
@@ -285,6 +296,8 @@ public class JSQLTranspilerTest {
     info.put("default_null_order", "NULLS FIRST");
     info.put("default_order", "ASC");
     info.put("memory_limit", "250M");
+    // VARIANT columns need storage version v1.5.0, new databases default to v1.0.0
+    info.put("storage_compatibility_version", "v1.5.0");
     // DuckDB 1.5+ JDBC driver uses JVM timezone for TIMESTAMPTZ formatting
     // instead of the DuckDB session timezone. Set JVM timezone to match.
     TimeZone.setDefault(TimeZone.getTimeZone("Asia/Bangkok"));

--- a/src/test/java/ai/starlake/transpiler/snowflake/SnowflakeVariantModeTest.java
+++ b/src/test/java/ai/starlake/transpiler/snowflake/SnowflakeVariantModeTest.java
@@ -1,0 +1,56 @@
+/**
+ * Starlake.AI JSQLTranspiler is a SQL to DuckDB Transpiler.
+ * Copyright (C) 2025 Starlake.AI (hayssam.saleh@starlake.ai)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.starlake.transpiler.snowflake;
+
+import ai.starlake.transpiler.JSQLTranspiler;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class SnowflakeVariantModeTest {
+
+  @Test
+  void snowflakeDefaultsToVariantBracketAccess() throws Exception {
+    Assertions
+        .assertThat(
+            JSQLTranspiler.transpileQuery("SELECT v:a.b FROM t", JSQLTranspiler.Dialect.SNOWFLAKE))
+        .isEqualToIgnoringWhitespace("SELECT v['a']['b'] FROM t");
+
+    Assertions
+        .assertThat(JSQLTranspiler.transpileQuery("SELECT v:arr[0] FROM t",
+            JSQLTranspiler.Dialect.SNOWFLAKE))
+        .isEqualToIgnoringWhitespace("SELECT v['arr'][1] FROM t");
+
+    Assertions
+        .assertThat(JSQLTranspiler.transpileQuery("SELECT x::VARIANT FROM t",
+            JSQLTranspiler.Dialect.SNOWFLAKE))
+        .isEqualToIgnoringWhitespace("SELECT x::VARIANT FROM t");
+  }
+
+  @Test
+  void jsonModeOnRequest() throws Exception {
+    Map<String, Object> params = Map.of("VARIANT_MODE", "JSON");
+
+    Assertions
+        .assertThat(JSQLTranspiler.transpileQuery("SELECT v:a.b::string FROM t",
+            JSQLTranspiler.Dialect.SNOWFLAKE, params))
+        .isEqualToIgnoringWhitespace("SELECT (v->'a'->>'b')::string FROM t");
+
+    Assertions
+        .assertThat(JSQLTranspiler.transpileQuery("SELECT x::VARIANT FROM t",
+            JSQLTranspiler.Dialect.SNOWFLAKE, params))
+        .isEqualToIgnoringWhitespace("SELECT x::VARCHAR FROM t");
+  }
+}

--- a/src/test/resources/ai/starlake/transpiler/snowflake/json.sql
+++ b/src/test/resources/ai/starlake/transpiler/snowflake/json.sql
@@ -83,3 +83,22 @@ SELECT ID, Try_Cast(v AS JSON) j
 
 -- epilog
 DROP TABLE IF EXISTS vartab;
+
+
+-- prolog
+DROP TABLE IF EXISTS jpath_tab;
+CREATE TABLE jpath_tab (id INTEGER, j VARCHAR);
+INSERT INTO jpath_tab VALUES (1, '{"a":{"b":"x"},"arr":[10,20,30]}');
+
+-- provided
+SELECT j:a.b AS b, j:a.b::string AS s, j:arr[0]::int AS n FROM jpath_tab;
+
+-- expected
+SELECT j->'a'->'b' AS b, (j->'a'->>'b')::string AS s, (j->'arr'->0)::int AS n FROM jpath_tab;
+
+-- result
+"b","s","n"
+"""x""","x","10"
+
+-- epilog
+DROP TABLE IF EXISTS jpath_tab;

--- a/src/test/resources/ai/starlake/transpiler/snowflake/variant.sql
+++ b/src/test/resources/ai/starlake/transpiler/snowflake/variant.sql
@@ -1,0 +1,93 @@
+-- prolog
+DROP TABLE IF EXISTS variant_tab;
+CREATE TABLE variant_tab (id INTEGER, v VARIANT);
+INSERT INTO variant_tab SELECT 1, '{"a":{"b":"x"},"arr":[10,20,30]}'::JSON::VARIANT;
+
+-- provided
+SELECT v:a.b AS b FROM variant_tab;
+
+-- expected
+SELECT v['a']['b'] AS b FROM variant_tab;
+
+-- result
+"b"
+"x"
+
+-- epilog
+DROP TABLE IF EXISTS variant_tab;
+
+
+-- prolog
+DROP TABLE IF EXISTS variant_tab;
+CREATE TABLE variant_tab (id INTEGER, v VARIANT);
+INSERT INTO variant_tab SELECT 1, '{"a":{"b":"x"},"arr":[10,20,30]}'::JSON::VARIANT;
+
+-- provided
+SELECT v:a.b::string AS s FROM variant_tab;
+
+-- expected
+SELECT v['a']['b']::string AS s FROM variant_tab;
+
+-- result
+"s"
+"x"
+
+-- epilog
+DROP TABLE IF EXISTS variant_tab;
+
+
+-- prolog
+DROP TABLE IF EXISTS variant_tab;
+CREATE TABLE variant_tab (id INTEGER, v VARIANT);
+INSERT INTO variant_tab SELECT 1, '{"a":{"b":"x"},"arr":[10,20,30]}'::JSON::VARIANT;
+
+-- provided
+SELECT v:arr[0]::int AS n FROM variant_tab;
+
+-- expected
+SELECT v['arr'][1]::int AS n FROM variant_tab;
+
+-- result
+"n"
+"10"
+
+-- epilog
+DROP TABLE IF EXISTS variant_tab;
+
+
+-- prolog
+DROP TABLE IF EXISTS variant_tab;
+CREATE TABLE variant_tab (id INTEGER, v VARIANT);
+INSERT INTO variant_tab SELECT 1, '{"a":{"b":"x"},"arr":[10,20,30]}'::JSON::VARIANT;
+
+-- provided
+SELECT v:a.missing IS NULL AS m FROM variant_tab;
+
+-- expected
+SELECT v['a']['missing'] IS NULL AS m FROM variant_tab;
+
+-- result
+"m"
+"true"
+
+-- epilog
+DROP TABLE IF EXISTS variant_tab;
+
+
+-- prolog
+DROP TABLE IF EXISTS variant_tab;
+CREATE TABLE variant_tab (id INTEGER, s VARCHAR);
+INSERT INTO variant_tab VALUES (1, 'x');
+
+-- provided
+SELECT s::VARIANT AS v FROM variant_tab;
+
+-- expected
+SELECT s::VARIANT AS v FROM variant_tab;
+
+-- result
+"v"
+"x"
+
+-- epilog
+DROP TABLE IF EXISTS variant_tab;


### PR DESCRIPTION
Closes #148

## Problem

Snowflake `:` variant paths were transpiled to a single dotted arrow step (`v:a.b` -> `v->'a.b'`), which DuckDB resolves to NULL, and a cast on the path (`v:a.b::string`) produced invalid SQL (`v->a.b::string`) because jsqlparser binds the cast inside the path ident. On DuckDB 1.4+ `VARIANT` columns, arrow operators fail entirely (`Malformed JSON` on the VARIANT->JSON cast), while native bracket access works and preserves the stored types.

## Changes

- `visit(JsonExpression)` now decomposes `:` path idents into one step per key and unwraps the inner cast.
- New `VARIANT_MODE` parameter (mirrors `GEO_MODE`), also readable from a system property:
  - `VARIANT` (default, since Starlake commits to DuckDB 1.4+ with native VARIANT columns): bracket access `v['a']['b']` preserving stored types; numeric array subscripts are shifted to DuckDB's 1-based bracket indexing (`v:arr[0]` -> `v['arr'][1]`); `::VARIANT` casts map to DuckDB `VARIANT` instead of `VARCHAR`.
  - `JSON` (opt-out for JSON/VARCHAR columns): per-step arrows `v->'a'->'b'`; when the path is cast to a text type the final step uses `->>` so strings come back unquoted as in Snowflake; other casts are parenthesized `(v->'a'->'b')::TIMESTAMP`. Array subscripts stay 0-based (`v:arr[0]` -> `v->'arr'->0`).
- Test harness: files whose name contains `variant` run with `VARIANT_MODE=VARIANT`; the test database is created with `storage_compatibility_version=v1.5.0` so VARIANT columns are usable.
- New `snowflake/variant.sql` tests (bracket access, text/int casts, 1-based subscript, missing key -> SQL NULL, `::VARIANT` rewrite) and a `snowflake/json.sql` case for `:` paths against JSON columns, all executed against DuckDB.

## Verification

- SnowflakeTranspilerTest: 127/127 pass (includes the 6 new cases); SnowflakeVariantModeTest guards the VARIANT default and the JSON opt-out. Test SQL files declare their mode explicitly (filename containing `variant` -> VARIANT, otherwise JSON), so existing JSON-column test files keep testing arrow emission.
- Full suite: identical failure set before and after the change (54 pre-existing failures on main, mostly ParseExceptions from the floating `jsqlparser:+` dependency); no new failures introduced.
- All emitted forms were validated by hand against DuckDB v1.5.4 (bracket access on VARIANT, 1-based subscripts, `->>` unquoted strings, VARIANT casts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
