### PR TITLE
fix: resolve correlated sub queries against the enclosing query

### DIFF
--- a/src/main/java/ai/starlake/transpiler/JSQLExpressionColumnResolver.java
+++ b/src/main/java/ai/starlake/transpiler/JSQLExpressionColumnResolver.java
@@ -90,6 +90,13 @@ public class JSQLExpressionColumnResolver extends ExpressionVisitorAdapter<List<
       // column has a table name prefix, which could be the actual table name or the table's
       // alias
       String actualColumnTableName = null;
+      if (!fromTables.containsKey(columnTableName)
+          && metaData.getOuterFromTables().containsKey(columnTableName)) {
+        // A correlated reference: the name is not one of this query's tables but is
+        // one of the enclosing query's. Unqualified columns never reach here, so the
+        // inner query keeps deciding what a bare column name means.
+        fromTables = metaData.getOuterFromTables();
+      }
       if (!fromTables.containsKey(columnTableName)) {
         switch (metaData.getErrorMode()) {
           case STRICT:
@@ -538,29 +545,41 @@ public class JSQLExpressionColumnResolver extends ExpressionVisitorAdapter<List<
   @Override
   public <S> List<JdbcColumn> visit(ParenthesedSelect select, S context) {
     ArrayList<JdbcColumn> columns = new ArrayList<>();
+    Object scope = nestedScope(context);
     if (select.getWithItemsList() != null) {
       for (WithItem<?> item : select.getWithItemsList()) {
-        columns.addAll(item.accept(columResolver, context).getColumns());
+        columns.addAll(item.accept(columResolver, scope).getColumns());
       }
     }
     columns.addAll(
-        select.accept((SelectVisitor<JdbcResultSetMetaData>) columResolver, context).getColumns());
+        select.accept((SelectVisitor<JdbcResultSetMetaData>) columResolver, scope).getColumns());
     return columns;
+  }
+
+  /**
+   * The scope a sub query in an expression is resolved in: its own FROM clause, plus
+   * the tables of the enclosing query as an outer scope a correlated reference may
+   * name. A context that is not metadata is handed on unchanged.
+   */
+  private static Object nestedScope(Object context) {
+    return context instanceof JdbcMetaData ? JdbcMetaData.copyOfNested((JdbcMetaData) context)
+        : context;
   }
 
   @Override
   public <S> List<JdbcColumn> visit(Select select, S context) {
     ArrayList<JdbcColumn> columns = new ArrayList<>();
+    Object scope = nestedScope(context);
     if (select.getWithItemsList() != null) {
       for (WithItem<?> item : select.getWithItemsList()) {
-        for (JdbcColumn col : item.accept(columResolver, context).getColumns()) {
+        for (JdbcColumn col : item.accept(columResolver, scope).getColumns()) {
           columns.add(col.setExpression(select));
         }
       }
     }
 
     for (JdbcColumn col : select
-        .accept((SelectVisitor<JdbcResultSetMetaData>) columResolver, context).getColumns()) {
+        .accept((SelectVisitor<JdbcResultSetMetaData>) columResolver, scope).getColumns()) {
       columns.add(col.setExpression(select));
     }
 
@@ -573,7 +592,7 @@ public class JSQLExpressionColumnResolver extends ExpressionVisitorAdapter<List<
     if (context instanceof JdbcMetaData) {
       JdbcResultSetMetaData resultSetMetaData =
           plainSelect.accept((SelectVisitor<JdbcResultSetMetaData>) columResolver,
-              JdbcMetaData.copyOf((JdbcMetaData) context));
+              nestedScope(context));
       columns.addAll(resultSetMetaData.getColumns());
     }
     return columns;
@@ -585,7 +604,7 @@ public class JSQLExpressionColumnResolver extends ExpressionVisitorAdapter<List<
     if (context instanceof JdbcMetaData) {
       JdbcResultSetMetaData resultSetMetaData =
           setOperationList.accept((SelectVisitor<JdbcResultSetMetaData>) columResolver,
-              JdbcMetaData.copyOf((JdbcMetaData) context));
+              nestedScope(context));
       columns.addAll(resultSetMetaData.getColumns());
     }
     return columns;

--- a/src/main/java/ai/starlake/transpiler/schema/JdbcMetaData.java
+++ b/src/main/java/ai/starlake/transpiler/schema/JdbcMetaData.java
@@ -63,6 +63,17 @@ public final class JdbcMetaData implements DatabaseMetaData {
   private final CaseInsensitiveLinkedHashMap<Table> fromTables =
       new CaseInsensitiveLinkedHashMap<>() {};
 
+  /**
+   * The tables of the queries enclosing this one, for a correlated sub query.
+   * <p>
+   * Separate from {@link #fromTables} on purpose: a qualified reference falls back
+   * to this scope when the name is not one of this query's own tables, while an
+   * unqualified column is looked up in {@link #fromTables} alone, so the inner
+   * query keeps deciding what a bare column name means.
+   */
+  private final CaseInsensitiveLinkedHashMap<Table> outerFromTables =
+      new CaseInsensitiveLinkedHashMap<>();
+
   private final CaseInsensitiveLinkedHashMap<Table> naturalJoinedTables =
       new CaseInsensitiveLinkedHashMap<>();
   private final CaseInsensitiveLinkedHashMap<Column> leftUsingJoinedColumns =
@@ -1840,6 +1851,11 @@ public final class JdbcMetaData implements DatabaseMetaData {
     return fromTables;
   }
 
+  /** The tables of the enclosing queries; empty unless this is a correlated sub query. */
+  public CaseInsensitiveLinkedHashMap<Table> getOuterFromTables() {
+    return outerFromTables;
+  }
+
   public JdbcMetaData addFromTables(Collection<Table> fromTables) {
     for (Table t : fromTables) {
       this.fromTables.put(t.getName(), t);
@@ -1890,6 +1906,9 @@ public final class JdbcMetaData implements DatabaseMetaData {
     JdbcMetaData metaData1 =
         new JdbcMetaData(metaData.currentCatalogName, metaData.currentSchemaName);
     metaData1.getFromTables().putAll(fromTables);
+    // The enclosing scope travels with the copy; only the query's own tables are
+    // decided per copy.
+    metaData1.outerFromTables.putAll(metaData.outerFromTables);
 
     for (JdbcCatalog catalog : metaData.catalogs.values()) {
       JdbcCatalog catalog1 = new JdbcCatalog(catalog.tableCatalog, metaData.catalogSeparator);
@@ -1915,6 +1934,18 @@ public final class JdbcMetaData implements DatabaseMetaData {
 
   public static JdbcMetaData copyOf(JdbcMetaData metaData) {
     return copyOf(metaData, new CaseInsensitiveLinkedHashMap<Table>());
+  }
+
+  /**
+   * The scope for a sub query that appears in an expression - {@code EXISTS},
+   * {@code IN}, a scalar select, {@code HAVING}. Its own FROM clause starts empty,
+   * and the tables of the enclosing query become the outer scope that a correlated
+   * reference resolves against.
+   */
+  public static JdbcMetaData copyOfNested(JdbcMetaData outer) {
+    JdbcMetaData nested = copyOf(outer);
+    nested.outerFromTables.putAll(outer.fromTables);
+    return nested;
   }
 
   public JdbcMetaData copyOf() {

--- a/src/test/java/ai/starlake/transpiler/JSQLResolverTest.java
+++ b/src/test/java/ai/starlake/transpiler/JSQLResolverTest.java
@@ -784,4 +784,107 @@ class JSQLResolverTest extends AbstractColumnResolverTest {
         .as("All %d invalid queries should be rejected by JSQLResolver", testQueries.length)
         .isEqualTo(testQueries.length);
   }
+
+  // --- correlated sub queries: a sub query in an expression may reference the
+  // tables of the query that encloses it. Only the sub query's own FROM clause was
+  // in scope, so every such reference was rejected as an undeclared table.
+
+  @Test
+  void testCorrelatedExists() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT a.col1 FROM a WHERE EXISTS (SELECT b.col1 FROM b WHERE b.col2 = a.col2)";
+
+    // a.col2 is the correlated reference: the outer table is in scope inside the sub query
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col2"}, {"a", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testCorrelatedIn() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT a.col1 FROM a WHERE a.col1 IN (SELECT b.col1 FROM b WHERE b.col2 = a.col2)";
+
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col2"}, {"a", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testCorrelatedScalarSubSelectInSelectList() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT a.col1, (SELECT max(b.col1) FROM b WHERE b.col2 = a.col2) FROM a";
+
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col1"}, {"b", "col2"}, {"a", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testCorrelatedWithAliases() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT x.col1 FROM a x WHERE EXISTS (SELECT y.col1 FROM b y WHERE y.col2 = x.col2)";
+
+    // reported against the real table names, not the aliases
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col2"}, {"a", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testCorrelatedInHaving() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT a.col1 FROM a GROUP BY a.col1"
+        + " HAVING count(a.col1) > (SELECT count(b.col1) FROM b WHERE b.col2 = a.col2)";
+
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col1"}, {"b", "col2"}, {"a", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testInnerTableShadowsOuterTableOfTheSameName() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    // b.col2 is the inner b, a.col2 the outer a: each name resolves in its own scope
+    String sqlStr = "SELECT a.col1 FROM a WHERE EXISTS (SELECT b.col1 FROM b WHERE b.col2 = a.col2)";
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    Assertions.assertThat(resolver.flatten(resolver.resolve(sqlStr)))
+        .contains(new JdbcColumn("b", "col2"), new JdbcColumn("a", "col2"));
+  }
+
+  @Test
+  void testUncorrelatedSubSelectStillResolves() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    String sqlStr = "SELECT a.col1 FROM a WHERE a.col1 IN (SELECT b.col1 FROM b WHERE b.col2 = 1)";
+
+    String[][] expectedColumns = {{"a", "col1"}, {"b", "col2"}};
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    assertThatTableAndColumnsMatch(resolver.resolve(sqlStr), expectedColumns);
+  }
+
+  @Test
+  void testDerivedTableInFromDoesNotSeeTheOuterQuery() throws JSQLParserException {
+    String[][] schemaDefinition = {{"a", "col1", "col2"}, {"b", "col1", "col2"}};
+
+    // a derived table in FROM is not correlated: a.col2 is not in scope there
+    String sqlStr = "SELECT t.col1 FROM a, (SELECT b.col1 FROM b WHERE b.col2 = a.col2) t";
+
+    JSQLResolver resolver = new JSQLResolver(schemaDefinition);
+    Assertions.assertThatThrownBy(() -> resolver.resolve(sqlStr))
+        .isInstanceOf(TableNotDeclaredException.class);
+  }
 }


### PR DESCRIPTION
## The problem

A sub query that appears in an expression — `EXISTS`, `IN`, a scalar select, `HAVING` — was resolved against its own `FROM` clause alone. Any reference to a table of the query enclosing it, which is what makes a sub query correlated, was rejected as undeclared:

```java
JSQLResolver resolver = new JSQLResolver(new String[][] {{"a", "col1", "col2"}, {"b", "col1", "col2"}});
resolver.resolve("SELECT a.col1 FROM a WHERE EXISTS (SELECT b.col1 FROM b WHERE b.col2 = a.col2)");

// ai.starlake.transpiler.TableNotDeclaredException: Table a not declared in [b]
```

Every correlated form failed the same way, whichever clause held the sub query and whether or not the tables were aliased:

| statement | before | after |
|---|---|---|
| `.. WHERE EXISTS (SELECT b.col1 FROM b WHERE b.col2 = a.col2)` | `Table a not declared in [b]` | resolves |
| `.. WHERE a.col1 IN (SELECT b.col1 FROM b WHERE b.col2 = a.col2)` | `Table a not declared in [b]` | resolves |
| `SELECT a.col1, (SELECT max(b.col1) FROM b WHERE b.col2 = a.col2) FROM a` | `Table a not declared in [b]` | resolves |
| `SELECT x.col1 FROM a x WHERE EXISTS (SELECT y.col1 FROM b y WHERE y.col2 = x.col2)` | `Table x not declared in [y]` | resolves |
| `.. HAVING count(a.col1) > (SELECT count(b.col1) FROM b WHERE b.col2 = a.col2)` | `Table a not declared in [b]` | resolves |
| uncorrelated `EXISTS` / `IN` / scalar select | resolves | resolves, unchanged |
| `SELECT a.col1 FROM a JOIN b ON b.col1 = a.col1` | resolves | resolves, unchanged |

## The change

`JdbcMetaData` gains an outer scope, filled from the enclosing query's `FROM` tables when an expression descends into a sub query, and carried along by `copyOf` so it survives the visitor dispatch. A qualified reference falls back to that scope when the name is not one of the sub query's own tables.

Two properties are deliberate:

- **The outer scope is separate from `getFromTables()`.** An unqualified column is still looked up in the sub query's own tables only, so the inner query keeps deciding what a bare column name means, and an inner table still shadows an outer one of the same name. Merging the two maps instead breaks exactly that: it made `testSubSelectLineage` and `testDiscussion2096` resolve a bare column against the outer table.
- **A derived table in a `FROM` clause is handed an empty scope.** It stays uncorrelated, which is what SQL requires without `LATERAL`. A test pins it.

## Tests

Eight tests in `JSQLResolverTest`: the five correlated forms above, the shadowing rule, an uncorrelated control, and the uncorrelated derived table.

Full suite on this branch: **1047 tests, 71 failed**. On `main` without the change: **1039 tests, 71 failed** — the same 71, all in `RedshiftTranspilerTest`, `BigQueryTranspilerTest` and `SnowflakeTranspilerTest`, red before this branch and untouched by it. No new failures.

Built and run with the JDK 17 toolchain.

## Why it matters

This surfaced in a SQL guard that uses `JSQLResolver` to check user-supplied SQL against a whitelisted catalog before it reaches a database. A correlated sub query is ordinary SQL that reporting tools generate unprompted, and the guard refused it with a message naming a table the user can plainly see, which reads like a typo rather than a limitation.
